### PR TITLE
feat: add upvote functionality for learning paths

### DIFF
--- a/src/components/UpvoteButton.js
+++ b/src/components/UpvoteButton.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Button, message } from 'antd';
+import { LikeOutlined } from '@ant-design/icons';
+import { useMutation } from '@apollo/react-hooks';
+import gql from 'graphql-tag';
+
+const UPVOTE_PATH = gql`
+  mutation UpvotePath($pathId: Int!, $userId: String!) {
+    update_learning_path_by_pk(pk_columns: {id: $pathId}, _append: {voted_by: [ $userId ]}) {
+      id
+      voted_by
+    }
+  }
+`;
+
+const UpvoteButton = ({ pathId, userId, votedBy = [] }) => {
+  const [upvote] = useMutation(UPVOTE_PATH);
+
+  const handleUpvote = async () => {
+    if (votedBy.includes(userId)) {
+      message.info('You have already upvoted this path!');
+      return;
+    }
+    try {
+      await upvote({ variables: { pathId, userId } });
+      message.success('Upvoted successfully!');
+    } catch (err) {
+      message.error('Failed to upvote');
+    }
+  };
+
+  return (
+    <Button icon={<LikeOutlined />} onClick={handleUpvote}>
+      {votedBy.length} Upvotes
+    </Button>
+  );
+};
+
+export default UpvoteButton;


### PR DESCRIPTION
Fixes #20

This PR introduces an `UpvoteButton` component that allows authenticated users to upvote learning paths. 

- Uses Apollo Client mutation to update the `upvoted_by` field (JSON/Array storage) in the database.
- Provides feedback to the user via Ant Design messages.
- Integrates with the existing GraphQL schema to manage user upvotes for better recommendation tracking.

---
*This PR was autonomously generated by [Pangea 3](https://github.com/sebmuehlbauer) — an AI-powered development system.*